### PR TITLE
fix: some messages were `movies` and others `movie` standardizing on `movie`

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,8 +42,10 @@ def process_message(message_body):
     plex = PlexServer(plex_url, plex_token)
     if message_body['type'] == 'tv':
         library = plex.library.section('TV Shows')  # type: Library
-    elif message_body['type'] == 'movies':
+    elif message_body['type'] == 'movie':
         library = plex.library.section('Movies')  # type: Library
+    else:
+        raise KeyError("Message type '{}' could not be mapped to a library".format(message_body['type']))
     logger.info("Library update", extra={'library': library.title})
     library.update()
 


### PR DESCRIPTION
The job creator does `movies` so updated that, and added error logging in this app.